### PR TITLE
fix relative link to Doctrine ActiveRecord

### DIFF
--- a/docs/input-validation/example.md
+++ b/docs/input-validation/example.md
@@ -58,4 +58,4 @@ class UserController
 }
 ```
 
-See also [Doctrine ActiveRecord - Object-oriented CRUD for Doctrine DBAL](../active-record.md)
+See also [Doctrine ActiveRecord - Object-oriented CRUD for Doctrine DBAL](../doctrine-active-record.md)


### PR DESCRIPTION
Simple fix for relative link to Doctrine ActiveRecord